### PR TITLE
Remove Container fzf prompt for kfor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Because it's fancy-kubectl!
 
 ## Installation
 
-You can directly download the [`fubectl.source`](https://rawgit.com/realfake/fubectl/master/fubectl.source)
+You can directly download the [`fubectl.source`](https://rawgit.com/kubermatic/fubectl/master/fubectl.source)
 and save it in some directory.
 
 Download:
 ```bash
-curl -LO https://rawgit.com/realfake/fubectl/master/fubectl.source
+curl -LO https://rawgit.com/kubermatic/fubectl/master/fubectl.source
 ```
 
 then add to your .bashrc/.zshrc file:

--- a/fubectl.source
+++ b/fubectl.source
@@ -78,8 +78,6 @@ kfor() {
   fi
 
   arg_pair="$(kubectl get po --all-namespaces | _inline_fzf | awk '{print $1, $2}')"
-  pods_out="$(echo $arg_pair | xargs kubectl get po -o=jsonpath='{.spec.containers[*].name}' -n)"
-  pod_choosen="$(echo $pods_out |  tr ' ' "\n" | _inline_fzf_nh)"
   echo "kubectl port-forward -n ${arg_pair} $1"
   eval kubectl port-forward -n "${arg_pair}" $1
 }


### PR DESCRIPTION
Port-forwarding doesn't need to know a specific Container inside a Pod.