### PR TITLE
Create kget which returns a resource as YAML

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -21,6 +21,19 @@ alias kwall="watch kubectl get pods --all-namespaces"
 # Open kubernetes dashboard
 alias kp="open 'http://localhost:8001/ui' && kubectl proxy"
 
+# kget (get a resource by its YAML)
+kget() {
+  case "$1" in
+  # TODO Add more
+  nodes|no|node|ns|namespace|namespaces)
+          kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl get -o yaml "${1}"
+          ;;
+  *)
+          kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl get -o yaml "${1}" -n
+          ;;
+  esac
+}
+
 # kdes (describe resource)
 kdes() {
   case "$1" in


### PR DESCRIPTION
Create the `kget` command which returns its YAML representation.
I think it's ok to go with YAML as a default here.
