### PR TITLE
use name of context instead name of cluster

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -113,7 +113,7 @@ alias kcl='kubectl config get-contexts'
 
 # kcs (context set)
 kcs() {
-  context="$(kubectl config get-contexts | _inline_fzf | awk '{print $2}')"
+  context="$(kubectl config get-contexts | _inline_fzf | awk '{print $1}')"
   eval kubectl config set current-context "${context}"
 }
 


### PR DESCRIPTION
use the correct column to extract the selected context instead of the cluster. fixes #7