### PR TITLE
Make kget/kwatch/kdes/kdel work on all resource types that are not namespaced

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -24,15 +24,12 @@ _is_non_namespaced_resource() {
 
 # [kwatch] watch resource
 kwatch() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _is_non_namespaced_resource $1
+    then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs watch kubectl get "${1}"
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs watch kubectl get "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [kdebug] start debugging in cluster
@@ -52,41 +49,32 @@ kube_ctx_namespace() {
 
 # [kget] get a resource by its YAML
 kget() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _is_non_namespaced_resource $1
+    then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl get -o yaml "${1}"
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl get -o yaml "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [kdes] describe resource
 kdes() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _is_non_namespaced_resource $1
+    then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl describe "${1}"
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl describe "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [kdel] delete resource
 kdel() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _is_non_namespaced_resource $1
+    then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "${1}"  
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -p kubectl delete "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [klog] fetch log from container

--- a/fubectl.source
+++ b/fubectl.source
@@ -14,6 +14,14 @@ alias kwall="watch kubectl get pods --all-namespaces"
 # [kp] open kubernetes dashboard with proxy
 alias kp="open 'http://localhost:8001/ui' && kubectl proxy"
 
+# Return ture if the given resource name is namespaced in k8s
+_is_non_namespaced_resource() {
+  non_namespaced_resource_names=$(kubectl api-resources --namespaced=false --no-headers=true | awk '{ print $1,$2 }' | tr ',' ' ' | tr '\n' ' ')
+  [[ $non_namespaced_resource_names =~ (^|[[:space:]])$1($|[[:space:]]) ||
+  # in case of plural form of the same name, e.g. node,nodes
+    $non_namespaced_resource_names =~ (^|[[:space:]])$1[s]($|[[:space:]]) ]] 
+}
+
 # [kwatch] watch resource
 kwatch() {
     case "$1" in


### PR DESCRIPTION
Currently the command `kget`, `kwatch`, `kdes`, `kdel` do not work with ClusterRole, PersistentVolumes and a few other resources that are not namespaced. I believe it's a known issue and was left as the `TODO` in the code.

This PR fixes this issue. It is based on the `kubectl api-resources` command, which can return all resource names that are not namespaced:
![image](https://user-images.githubusercontent.com/489344/51424934-fbc56d00-1b89-11e9-9461-d9cce89dab7f.png)

Manually tested with both Zsh and Bash on MacOS.
![image](https://user-images.githubusercontent.com/489344/51425053-c15ccf80-1b8b-11e9-8388-b97416b89655.png)
