### PR TITLE
add namespace,dashboard fix and new commands `ka`,`kwa`, `ked`

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -1,30 +1,54 @@
 # helper functions
 alias _inline_fzf="fzf --multi --ansi -i -1 --height=50% --reverse -0 --header-lines=1 --inline-info --border"
 alias _inline_fzf_nh="fzf --multi --ansi -i -1 --height=50% --reverse -0 --inline-info --border"
+_isNamespaced(){
+    if [[ "$1" == "" ]]; then
+        echo "please specify a Kubernetes object!"
+        exit 1
+    fi
+    # ask cluster about not namespaced resources
+    if [ $(kubectl api-resources --no-headers --namespaced=false | awk '{print $1,$2,$4}' | sed 's/ /\n/g' | grep --count -i "^$1$")  -gt 0 ]; then
+        return 0
+   else
+        return 1
+    fi
+}
 
 # [k] like g for git but 233% as effective!
 alias k="kubectl"
 
-# [kall] get all pods
+# [ka] get all pods in namespace
+alias ka="kubectl get pods"
+
+# [kall] get all pods in cluster
 alias kall="kubectl get pods --all-namespaces"
 
-# [kwall] watch all pods
+# [kwa] watch all pods in namespace
+alias kwa="watch kubectl get pods"
+
+# [kwall] watch all pods in cluster
 alias kwall="watch kubectl get pods --all-namespaces"
 
+# TODO check if this works for macs
 # [kp] open kubernetes dashboard with proxy
-alias kp="open 'http://localhost:8001/ui' && kubectl proxy"
+alias kp="xdg-open 'http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/' && kubectl proxy"
+
+# TODO remove after review
+ktestNamespaced() {
+    if _isNamespaced $1 ; then
+        echo "namespaced!"
+    else
+        echo ":-("
+    fi
+}
 
 # [kwatch] watch resource
 kwatch() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _isNamespaced $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs watch kubectl get "${1}"
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs watch kubectl get "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [kdebug] start debugging in cluster
@@ -44,41 +68,38 @@ kube_ctx_namespace() {
 
 # [kget] get a resource by its YAML
 kget() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _isNamespaced $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl get -o yaml "${1}"
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl get -o yaml "${1}" -n
-    ;;
-    esac
+    fi
+}
+
+# [ked] edit a resource by its YAML
+ked() {
+    if _isNamespaced $1 ; then
+        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl edit "${1}"
+    else
+        kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl edit "${1}" -n
+    fi
 }
 
 # [kdes] describe resource
 kdes() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
+    if _isNamespaced $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl describe "${1}"
-    ;;
-    *)
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl describe "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [kdel] delete resource
 kdel() {
-    case "$1" in
-    # TODO Add more
-    nodes|no|node|ns|namespace|namespaces)
-        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "${1}"  
-    ;;
-    *)
+    if _isNamespaced $1 ; then
+        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "${1}"
+    else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -p kubectl delete "${1}" -n
-    ;;
-    esac
+    fi
 }
 
 # [klog] fetch log from container

--- a/fubectl.source
+++ b/fubectl.source
@@ -23,7 +23,7 @@ alias ka="kubectl get pods"
 # [kall] get all pods in cluster
 alias kall="kubectl get pods --all-namespaces"
 
-# [kwa] watch all pods in namespace
+# [kwa] watch all pods in the current namespace
 alias kwa="watch kubectl get pods"
 
 # [kwall] watch all pods in cluster

--- a/fubectl.source
+++ b/fubectl.source
@@ -1,19 +1,18 @@
 # helper functions
 alias _inline_fzf="fzf --multi --ansi -i -1 --height=50% --reverse -0 --header-lines=1 --inline-info --border"
 alias _inline_fzf_nh="fzf --multi --ansi -i -1 --height=50% --reverse -0 --inline-info --border"
-_isNamespaced(){
-    if [[ "$1" == "" ]]; then
-        echo "please specify a Kubernetes object!"
-        exit 1
-    fi
-    # ask cluster about not namespaced resources
-    if [ $(kubectl api-resources --no-headers --namespaced=false | awk '{print $1,$2,$4}' | sed 's/ /\n/g' | grep --count -i "^$1$")  -gt 0 ]; then
-        return 0
-   else
-        return 1
-    fi
-}
 
+_isClusterSpaceObject() {
+  obj="$1"
+  if [ -z "$obj" ]; then
+    echo "please specify a Kubernetes object!"
+    exit 1
+  fi
+
+  kubectl api-resources --namespaced=false \
+        | awk '(apiidx){print substr($0, 0, apiidx),substr($0, kindidx) } (!apiidx){ apiidx=index($0, " APIGROUP");kindidx=index($0, " KIND")}' \
+    | grep -iq "\<${obj}\>"
+}
 # [k] like g for git but 233% as effective!
 alias k="kubectl"
 
@@ -33,18 +32,9 @@ alias kwall="watch kubectl get pods --all-namespaces"
 # [kp] open kubernetes dashboard with proxy
 alias kp="xdg-open 'http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/' && kubectl proxy"
 
-# TODO remove after review
-ktestNamespaced() {
-    if _isNamespaced $1 ; then
-        echo "namespaced!"
-    else
-        echo ":-("
-    fi
-}
-
 # [kwatch] watch resource
 kwatch() {
-    if _isNamespaced $1 ; then
+    if _isClusterSpaceObject $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs watch kubectl get "${1}"
     else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs watch kubectl get "${1}" -n
@@ -68,7 +58,7 @@ kube_ctx_namespace() {
 
 # [kget] get a resource by its YAML
 kget() {
-    if _isNamespaced $1 ; then
+    if _isClusterSpaceObject $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl get -o yaml "${1}"
     else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl get -o yaml "${1}" -n
@@ -77,7 +67,7 @@ kget() {
 
 # [ked] edit a resource by its YAML
 ked() {
-    if _isNamespaced $1 ; then
+    if _isClusterSpaceObject $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl edit "${1}"
     else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl edit "${1}" -n
@@ -86,7 +76,7 @@ ked() {
 
 # [kdes] describe resource
 kdes() {
-    if _isNamespaced $1 ; then
+    if _isClusterSpaceObject $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl describe "${1}"
     else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl describe "${1}" -n
@@ -95,7 +85,7 @@ kdes() {
 
 # [kdel] delete resource
 kdel() {
-    if _isNamespaced $1 ; then
+    if _isClusterSpaceObject $1 ; then
         kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "${1}"
     else
         kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -p kubectl delete "${1}" -n

--- a/fubectl.source
+++ b/fubectl.source
@@ -30,7 +30,7 @@ alias kwall="watch kubectl get pods --all-namespaces"
 
 # TODO check if this works for macs
 # [kp] open kubernetes dashboard with proxy
-alias kp="xdg-open 'http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/' && kubectl proxy"
+alias kp="xdg-open 'http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/' & kubectl proxy"
 
 # [kwatch] watch resource
 kwatch() {


### PR DESCRIPTION
Fixes:
* Resolving if an object is namespaced is no dynamic and should handle well with CRDs
* Link for open the Kubernetes Dashboard adjust to the default proxy link. Replace `open` with `xdg-open`

New:
* `ka` get all pods in namespace
* `kwa` watch all pods in namespace
* `ked` edit a resource by its YAML