### PR TITLE
Fix `ked`: change the way `kubectl edit` is called

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -67,11 +67,17 @@ kget() {
 
 # [ked] edit a resource by its YAML
 ked() {
-    if _isClusterSpaceObject $1 ; then
-        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl edit "${1}"
-    else
-        kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl edit "${1}" -n
+    kind="$1"
+    if [ -z "$kind" ]; then
+      echo "ked requires resource-type (pod,deployment,...) as argument."
+      return
     fi
+    if _isClusterSpaceObject $kind ; then
+        edit_args=$(kubectl get "$kind" | _inline_fzf | awk '{print $1}')
+    else
+        edit_args=$(kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print "-n", $1, $2}')
+    fi
+    kubectl edit "$kind" $edit_args
 }
 
 # [kdes] describe resource


### PR DESCRIPTION
Previously `kubectl edit` was called in a xargs pipe. This
causes problems with the stdio file descriptors resulting
in unavaible tty for the editor.
This change splits breaks the `kubectl edit` out into its
own command execution to fix that issue.
This change also prevents your shell from terminating when
(incorrectly) calling `ked` without argument.

Fixes #22 