### PR TITLE
Fix `ked` for zsh use.

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -73,11 +73,11 @@ ked() {
       return
     fi
     if _isClusterSpaceObject $kind ; then
-        edit_args=$(kubectl get "$kind" | _inline_fzf | awk '{print $1}')
+        edit_args=( $(kubectl get "$kind" | _inline_fzf | awk '{print $1}') )
     else
-        edit_args=$(kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print "-n", $1, $2}')
+        edit_args=( $(kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print "-n", $1, $2}') )
     fi
-    kubectl edit "$kind" $edit_args
+    kubectl edit "$kind" ${edit_args[*]}
 }
 
 # [kdes] describe resource


### PR DESCRIPTION
Previously `ked` relied on implicit word split in variable
substitution, which zsh does not do by default (shwordsplit
option). This change uses more explicit array feature in a
way that is compatible with both shells at the same time.