### PR TITLE
fix bash exit on empty argument

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -2,13 +2,15 @@
 alias _inline_fzf="fzf --multi --ansi -i -1 --height=50% --reverse -0 --header-lines=1 --inline-info --border"
 alias _inline_fzf_nh="fzf --multi --ansi -i -1 --height=50% --reverse -0 --inline-info --border"
 
-_isClusterSpaceObject() {
+_isObjectSpecified(){
   obj="$1"
   if [ -z "$obj" ]; then
     echo "please specify a Kubernetes object!"
-    exit 1
+    return 1
   fi
+}
 
+_isClusterSpaceObject() {
   kubectl api-resources --namespaced=false \
         | awk '(apiidx){print substr($0, 0, apiidx),substr($0, kindidx) } (!apiidx){ apiidx=index($0, " APIGROUP");kindidx=index($0, " KIND")}' \
     | grep -iq "\<${obj}\>"
@@ -34,10 +36,12 @@ alias kp="xdg-open 'http://localhost:8001/api/v1/namespaces/kube-system/services
 
 # [kwatch] watch resource
 kwatch() {
-    if _isClusterSpaceObject $1 ; then
-        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs watch kubectl get "${1}"
-    else
-        kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs watch kubectl get "${1}" -n
+    if _isObjectSpecified $1 ; then
+        if _isClusterSpaceObject ; then
+            kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs watch kubectl get "${1}"
+        else
+            kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs watch kubectl get "${1}" -n
+        fi
     fi
 }
 
@@ -58,43 +62,47 @@ kube_ctx_namespace() {
 
 # [kget] get a resource by its YAML
 kget() {
-    if _isClusterSpaceObject $1 ; then
-        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl get -o yaml "${1}"
-    else
-        kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl get -o yaml "${1}" -n
+    if _isObjectSpecified $1 ; then
+        if _isClusterSpaceObject ; then
+            kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl get -o yaml "${1}"
+        else
+            kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl get -o yaml "${1}" -n
+        fi
     fi
 }
 
 # [ked] edit a resource by its YAML
 ked() {
-    kind="$1"
-    if [ -z "$kind" ]; then
-      echo "ked requires resource-type (pod,deployment,...) as argument."
-      return
+    if _isObjectSpecified $1 ; then
+        kind=$1
+        if _isClusterSpaceObject ; then
+            edit_args=( $(kubectl get "$kind" | _inline_fzf | awk '{print $1}') )
+        else
+            edit_args=( $(kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print "-n", $1, $2}') )
+        fi
+        kubectl edit "$kind" ${edit_args[*]}
     fi
-    if _isClusterSpaceObject $kind ; then
-        edit_args=( $(kubectl get "$kind" | _inline_fzf | awk '{print $1}') )
-    else
-        edit_args=( $(kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print "-n", $1, $2}') )
-    fi
-    kubectl edit "$kind" ${edit_args[*]}
 }
 
 # [kdes] describe resource
 kdes() {
-    if _isClusterSpaceObject $1 ; then
-        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl describe "${1}"
-    else
-        kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl describe "${1}" -n
+    if _isObjectSpecified $1 ; then
+        if _isClusterSpaceObject ; then
+            kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs kubectl describe "${1}"
+        else
+            kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl describe "${1}" -n
+        fi
     fi
 }
 
 # [kdel] delete resource
 kdel() {
-    if _isClusterSpaceObject $1 ; then
-        kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "${1}"
-    else
-        kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -p kubectl delete "${1}" -n
+    if _isObjectSpecified $1 ; then
+        if _isClusterSpaceObject ; then
+            kubectl get "${1}" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "${1}"
+        else
+            kubectl get "${1}" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -p kubectl delete "${1}" -n
+        fi
     fi
 }
 


### PR DESCRIPTION
Currently if a users missed to specify a typ on e.g. `kdes` the bash exit due the sourced `exit 1` command.
Fixed this with `return 1` and nested if. Maybe not the elegant way, but seems to be a safe way ;-)