### PR TITLE
modify debug image

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -40,7 +40,9 @@ kwatch() {
 }
 
 # [kdebug] start debugging container (nicolaka/netshoot) in the current namespace
-alias kdebug='kubectl run --generator=run-pod/v1 tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
+kdebug() {
+    kubectl run --generator=run-pod/v1 kdebug-$RANDOM --rm -i --tty --image nicolaka/netshoot -- /bin/bash
+}
 
 # [kube_ctx_name] get the current context
 kube_ctx_name() {
@@ -189,14 +191,14 @@ kwns() {
 
 # [kbash] create a pod (ubuntu) with a bash
 kbash() {
-    kubectl run --generator=run-pod/v1 shell-$RANDOM --rm -i --tty --image ubuntu -- bash
+    kubectl run --generator=run-pod/v1 kbash-$RANDOM --rm -i --tty --image ubuntu -- bash
 }
 
 # [konsole] create root shell (alpine) on a node
 konsole() {
     local node="$(kubectl get node | _inline_fzf | awk '{print $1}')"
     local ns="$(kubectl get ns | _inline_fzf | awk '{print $1}')"
-    local name=shell-$RANDOM
+    local name=konsole-$RANDOM
     local overrides='
 {
     "spec": {

--- a/fubectl.source
+++ b/fubectl.source
@@ -40,7 +40,7 @@ kwatch() {
 }
 
 # [kdebug] start debugging in cluster
-alias kdebug='kubectl run test --rm --restart=Never -it --image=ubuntu -- bash'
+alias kdebug='kubectl run --generator=run-pod/v1 tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
 
 # [kube_ctx_name] get the current context
 kube_ctx_name() {
@@ -187,12 +187,12 @@ kwns() {
     watch kubectl get pod -n "$ns"
 }
 
-# [kbash] create a pod with a bash
+# [kbash] create a pod (ubuntu) with a bash
 kbash() {
     kubectl run --generator=run-pod/v1 shell-$RANDOM --rm -i --tty --image ubuntu -- bash
 }
 
-# [konsole] create root shell on a node
+# [konsole] create root shell (alpine) on a node
 konsole() {
     local node="$(kubectl get node | _inline_fzf | awk '{print $1}')"
     local ns="$(kubectl get ns | _inline_fzf | awk '{print $1}')"

--- a/fubectl.source
+++ b/fubectl.source
@@ -39,7 +39,7 @@ kwatch() {
     fi
 }
 
-# [kdebug] start debugging in cluster
+# [kdebug] start debugging container (nicolaka/netshoot) in the current namespace
 alias kdebug='kubectl run --generator=run-pod/v1 tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
 
 # [kube_ctx_name] get the current context


### PR DESCRIPTION
Currently `kbash` and `kdebug` does the same. To do prober debuging the container image of https://github.com/nicolaka/netshoot is much more helpful, becaue all needed tools are already installed.