### PR TITLE
fix konsole hostname selection

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -194,7 +194,7 @@ kbash() {
 
 # [konsole] create root shell on a node
 konsole() {
-    local node="$(kubectl get node | _inline_fzf | awk '{print $1}')"
+    local node_hostname="$(kubectl get node --label-columns=kubernetes.io/hostname | _inline_fzf | awk '{print $6}')"
     local ns="$(kubectl get ns | _inline_fzf | awk '{print $1}')"
     local name=shell-$RANDOM
     local overrides='
@@ -224,7 +224,7 @@ konsole() {
             }
         ],
         "nodeSelector": {
-            "kubernetes.io/hostname": "'$node'"
+            "kubernetes.io/hostname": "'$node_hostname'"
         }
     }
 }


### PR DESCRIPTION
The nodeSelector of `kubernetes.io/hostname` currently only works if the hostname match to the node `name`. E.g. on AWS this is not the case:

```
k get nodes --label-columns=kubernetes.io/hostname
NAME                                         STATUS   ROLES    AGE   VERSION   HOSTNAME
ip-172-31-44-68.eu-west-1.compute.internal   Ready    <none>   10h   v1.14.1   ip-172-31-44-68
```