### PR TITLE
[konsole] Use hostNetwork to function without cni.

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -201,6 +201,7 @@ konsole() {
 {
     "spec": {
         "hostPID": true,
+        "hostNetwork": true,
         "containers": [
             {
                 "name": "'$name'",


### PR DESCRIPTION
The pod surrounding the nsenter call will now run
in hostnetwork. This allows `konsole` to work even
if CNI is not coming up.