### PR TITLE
ZSH plugin added

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ then add to your .bashrc/.zshrc file:
 [ -f <path-to>/fubectl.source ] && source <path-to>/fubectl.source
 ```
 
+Alternatively you can install fubectl using the ZSH plugin manager of your
+choice.
+
 ## What can it do?
 
 ### k - alias for kubectl

--- a/fubectl.plugin.zsh
+++ b/fubectl.plugin.zsh
@@ -1,0 +1,1 @@
+. "$(dirname "${(%):-%N}")/fubectl.source"


### PR DESCRIPTION
Added a ZSH plugin source file to allow fubectl to be managed by common ZSH plugin managers such as antigen, antibody and oh-my-zsh.