### PR TITLE
add kw alias for `watch kubectl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Usage:
 
 ---
 
+### kw - alias for 'watch kubectl'
+
+
+Examples:
+ - `kw get nodes`
+ - `kw get pods`
+ - `kw get nodes,pods,services`
+
+---
+
 ### kall - All pods in all namespaces
 
 Get all pods

--- a/fubectl.source
+++ b/fubectl.source
@@ -12,6 +12,9 @@ _isClusterSpaceObject() {
 # [k] like g for git but 233% as effective!
 alias k="kubectl"
 
+# [kw] kw get po,svc,md
+alias kw="watch kubectl"
+
 # [ka] get all pods in namespace
 alias ka="kubectl get pods"
 
@@ -24,7 +27,7 @@ alias kwa="watch kubectl get pods"
 # [kwall] watch all pods in cluster
 alias kwall="watch kubectl get pods --all-namespaces"
 
-# TODO check if this works for macs
+# TODO use "open" instead of "xdg-open" on a mac - also redirect xdg-open std{out,err} to /dev/null
 # [kp] open kubernetes dashboard with proxy
 alias kp="xdg-open 'http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/' & kubectl proxy"
 

--- a/fubectl.source
+++ b/fubectl.source
@@ -13,7 +13,7 @@ _isClusterSpaceObject() {
 alias k="kubectl"
 
 # [kw] kw get po,svc,md
-alias kw="watch kubectl"
+alias kw="watch kubectl get"
 
 # [ka] get all pods in namespace
 alias ka="kubectl get pods"


### PR DESCRIPTION
I often find myself in the place where i need to watch different object types at once like this:

`watch kubectl get po,no,md,ms,machine -A`

but it is so much more handy to write:

`kw get po,no,md,ms,machine -A`

BTW: @scheeles @toschneck how do we create these fancy terminal gifs? I want to add one for the kw command