### PR TITLE
add kexp and kget-exp as replacement for removed kubectl `--export` flag

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -86,6 +86,17 @@ kget() {
     fi
 }
 
+# [kget-ex] get a resource by its YAML as former `--export` flag
+kget-ex() {
+    kget "$@" \
+    | yq d - 'metadata.resourceVersion' \
+    | yq d - 'metadata.uid' \
+    | yq d - 'metadata.creationTimestamp' \
+    | yq d - 'metadata.selfLink' \
+    | yq d - 'metadata.managedFields'\
+    | yq d - 'status'
+}
+
 # [ked] edit a resource by its YAML
 ked() {
     local kind="$1"

--- a/fubectl.source
+++ b/fubectl.source
@@ -316,16 +316,3 @@ khelp() {
     fi
 }
 
-#### CUSTOM TOBI
-# [kdebug] start debugging container (nicolaka/netshoot) in the current namespace
-kdebug() {
-    kcmd 'bash' 'nicolaka/netshoot'
-}
-
-# [k8c-cluster] extracts kubeconfig of user cluster and connects it in a new bash
-k8c-cluster () {
-	TMP_KUBECONFIG=$(mktemp)
-	local cluster="$(kubectl get cluster | _inline_fzf | awk '{print $1}')"
-	kubectl get secret admin-kubeconfig -n cluster-$cluster -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > $TMP_KUBECONFIG
-	KUBECONFIG=$TMP_KUBECONFIG $SHELL
-}

--- a/fubectl.source
+++ b/fubectl.source
@@ -93,8 +93,8 @@ kget-ex() {
     | yq d - 'metadata.uid' \
     | yq d - 'metadata.creationTimestamp' \
     | yq d - 'metadata.selfLink' \
-    | yq d - 'metadata.managedFields'\
-    | yq d - 'metadata.annotations.kubectl*'\
+    | yq d - 'metadata.managedFields' \
+    | yq d - 'metadata.annotations.kubectl*' \
     | yq d - 'status'
 }
 

--- a/fubectl.source
+++ b/fubectl.source
@@ -86,16 +86,25 @@ kget() {
     fi
 }
 
-# [kget-ex] get a resource by its YAML as former `--export` flag
-kget-ex() {
-    kget "$@" |
-        yq d - 'metadata.resourceVersion' |
-        yq d - 'metadata.uid' |
-        yq d - 'metadata.creationTimestamp' |
-        yq d - 'metadata.selfLink' |
-        yq d - 'metadata.managedFields' |
-        yq d - 'metadata.annotations.kubectl*' |
-        yq d - 'status'
+# [kexp] as former `--export` field removes unwanted metadata - usage: COMMAND | kexp
+kexp(){
+  if [ -t 0 ]; then
+    echo "kexp has no piped input!"
+    echo "usage: COMMAND | kexp"
+  else
+    yq d - 'metadata.resourceVersion' |
+    yq d - 'metadata.uid' |
+    yq d - 'metadata.creationTimestamp' |
+    yq d - 'metadata.selfLink' |
+    yq d - 'metadata.managedFields' |
+    yq d - 'metadata.annotations.kubectl*' |
+    yq d - 'status'
+  fi
+}
+
+# [kget-exp] get a resource by its YAML as former `--export` flag
+kget-exp() {
+    kget "$@" | kexp
 }
 
 # [ked] edit a resource by its YAML
@@ -232,11 +241,11 @@ ktree() {
     fi
 }
 
-# [konsole] create root shell on a node
+# [konsole] create root shell (alpine) on a node
 konsole() {
     local node_hostname="$(kubectl get node --label-columns=kubernetes.io/hostname | _inline_fzf | awk '{print $6}')"
     local ns="$(kubectl get ns | _inline_fzf | awk '{print $1}')"
-    local name=shell-$RANDOM
+    local name=konsole-$RANDOM
     local overrides='
 {
     "spec": {
@@ -277,7 +286,7 @@ konsole() {
 ksec () {
     ns=$(kubectl get ns | _inline_fzf | awk '{print $1}')
     local secret=$(kubectl get secret -n "$ns" | _inline_fzf | awk '{print $1}')
-    local key=$(kubectl get secret -n "$ns" "$secret" -o json | jq -r '.data | to_entries[] | "\(.key)"' | _inline_fzf_nh)       
+    local key=$(kubectl get secret -n "$ns" "$secret" -o json | jq -r '.data | to_entries[] | "\(.key)"' | _inline_fzf_nh)
     kubectl view-secret -n "$ns" "$secret" "$key"
 }
 
@@ -305,4 +314,18 @@ khelp() {
     else
         grep -E '^# \[.+\]' "${BASH_SOURCE[0]}"
     fi
+}
+
+#### CUSTOM TOBI
+# [kdebug] start debugging container (nicolaka/netshoot) in the current namespace
+kdebug() {
+    kcmd 'bash' 'nicolaka/netshoot'
+}
+
+# [k8c-cluster] extracts kubeconfig of user cluster and connects it in a new bash
+k8c-cluster () {
+	TMP_KUBECONFIG=$(mktemp)
+	local cluster="$(kubectl get cluster | _inline_fzf | awk '{print $1}')"
+	kubectl get secret admin-kubeconfig -n cluster-$cluster -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > $TMP_KUBECONFIG
+	KUBECONFIG=$TMP_KUBECONFIG $SHELL
 }

--- a/fubectl.source
+++ b/fubectl.source
@@ -92,13 +92,8 @@ kexp(){
     echo "kexp has no piped input!"
     echo "usage: COMMAND | kexp"
   else
-    yq d - 'metadata.resourceVersion' |
-    yq d - 'metadata.uid' |
-    yq d - 'metadata.creationTimestamp' |
-    yq d - 'metadata.selfLink' |
-    yq d - 'metadata.managedFields' |
-    yq d - 'metadata.annotations.kubectl*' |
-    yq d - 'status'
+    # remove not neat fields
+    kubectl neat
   fi
 }
 
@@ -241,11 +236,11 @@ ktree() {
     fi
 }
 
-# [konsole] create root shell (alpine) on a node
+# [konsole] create root shell on a node
 konsole() {
     local node_hostname="$(kubectl get node --label-columns=kubernetes.io/hostname | _inline_fzf | awk '{print $6}')"
     local ns="$(kubectl get ns | _inline_fzf | awk '{print $1}')"
-    local name=konsole-$RANDOM
+    local name=shell-$RANDOM
     local overrides='
 {
     "spec": {
@@ -304,6 +299,7 @@ ksec () {
 kinstall() {
     kubectl krew install tree
     kubectl krew install view-secret
+    kubectl krew install neat
 }
 # [kupdate] Updates kubectl plugins
 kupdate() {

--- a/fubectl.source
+++ b/fubectl.source
@@ -88,14 +88,14 @@ kget() {
 
 # [kget-ex] get a resource by its YAML as former `--export` flag
 kget-ex() {
-    kget "$@" \
-    | yq d - 'metadata.resourceVersion' \
-    | yq d - 'metadata.uid' \
-    | yq d - 'metadata.creationTimestamp' \
-    | yq d - 'metadata.selfLink' \
-    | yq d - 'metadata.managedFields' \
-    | yq d - 'metadata.annotations.kubectl*' \
-    | yq d - 'status'
+    kget "$@" |
+        yq d - 'metadata.resourceVersion' |
+        yq d - 'metadata.uid' |
+        yq d - 'metadata.creationTimestamp' |
+        yq d - 'metadata.selfLink' |
+        yq d - 'metadata.managedFields' |
+        yq d - 'metadata.annotations.kubectl*' |
+        yq d - 'status'
 }
 
 # [ked] edit a resource by its YAML

--- a/fubectl.source
+++ b/fubectl.source
@@ -94,6 +94,7 @@ kget-ex() {
     | yq d - 'metadata.creationTimestamp' \
     | yq d - 'metadata.selfLink' \
     | yq d - 'metadata.managedFields'\
+    | yq d - 'metadata.annotations.kubectl*'\
     | yq d - 'status'
 }
 


### PR DESCRIPTION
For creating a fast template of current deployment manifests without metadata and status fields:
```
#fuzzy option
kget-exp pod > pod.yaml

#dedicated usage
k get pod NAME | kexp | pod.yaml
```