### PR TITLE
fix: do not call kubectl on empty fzf output

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -123,9 +123,9 @@ kdes() {
     local kind="$1"
     [ -z "$kind" ] && printf "kdes: missing argument.\nUsage: kdes RESOURCE\n" && return 255
     if _isClusterSpaceObject "$kind" ; then
-        kubectl get "$kind" | _inline_fzf | awk '{print $1}' | xargs kubectl describe "$kind"
+        kubectl get "$kind" | _inline_fzf | awk '{print $1}' | xargs -r kubectl describe "$kind"
     else
-        kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs kubectl describe "$kind" -n
+        kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -r kubectl describe "$kind" -n
     fi
 }
 
@@ -134,9 +134,9 @@ kdel() {
     local kind="$1"
     [ -z "$kind" ] && printf "kdel: missing argument.\nUsage: kdel RESOURCE\n" && return 255
     if _isClusterSpaceObject "$kind" ; then
-        kubectl get "$kind" | _inline_fzf | awk '{print $1}' | xargs -p kubectl delete "$kind"
+        kubectl get "$kind" | _inline_fzf | awk '{print $1}' | xargs -r -p kubectl delete "$kind"
     else
-        kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -p kubectl delete "$kind" -n
+        kubectl get "$kind" --all-namespaces | _inline_fzf | awk '{print $1, $2}' | xargs -r -p kubectl delete "$kind" -n
     fi
 }
 


### PR DESCRIPTION
Hello

#### Issue

When fzf dropdown is shown - user may click `Esc` key, leaving choice is empty.
For some commands like `kdes`, `kdel` - the empty output is passed downstream to `xargs kubectl` making the command fail and show unnecessary error message.

#### Solution
`xargs` tool has following flag 
```
-r, --no-run-if-empty
              If the standard input does not contain any nonblanks, do not run the command.  Normally, the command is run once even if there is no input.  This option is a
              GNU extension.
```
Using this flag will disable call of `kubectl` on empty output of `fzf` thus preventing console screen polluting with error message.              

#### Status of this proposal

This is an intermediate fix just to present a possibility to improve user experience. In case this PR is accepted - I could review all remaining commands and apply fix to them as well.