### PR TITLE
Kubectl native secret viewer

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -306,14 +306,13 @@ konsole() {
 ksec () {
     ns=$(kubectl get ns | _inline_fzf | awk '{print $1}')
     local secret=$(kubectl get secret -n "$ns" | _inline_fzf | awk '{print $1}')
-    local key=$(kubectl get secret -n "$ns" "$secret" -o json | jq -r '.data | to_entries[] | "\(.key)"' | _inline_fzf_nh)
-    kubectl view-secret -n "$ns" "$secret" "$key"
+    local key=$(kubectl get secret -n "$ns" "$secret" -o go-template='{{- range $k,$v := .data -}}{{- printf "%s\n" $k -}}{{- end -}}' | _inline_fzf_nh)
+    kubectl get secret -n "$ns" "$secret" -o go-template='{{ index .data "'$key'" | base64decode }}'
 }
 
 # [kinstall] Install the required kubectl plugins
 kinstall() {
     kubectl krew install tree
-    kubectl krew install view-secret
     kubectl krew install neat
 }
 # [kupdate] Updates kubectl plugins
@@ -324,10 +323,10 @@ kupdate() {
 #### Kubermatic KKP specific
 # [kkp-cluster] Kubermatic KKP - extracts kubeconfig of user cluster and connects it in a new bash
 kkp-cluster () {
-	TMP_KUBECONFIG=$(mktemp)
-	local cluster="$(kubectl get cluster | _inline_fzf | awk '{print $1}')"
-	kubectl get secret admin-kubeconfig -n cluster-$cluster -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > $TMP_KUBECONFIG
-	KUBECONFIG=$TMP_KUBECONFIG $SHELL
+    TMP_KUBECONFIG=$(mktemp)
+    local cluster="$(kubectl get cluster | _inline_fzf | awk '{print $1}')"
+    kubectl get secret admin-kubeconfig -n cluster-$cluster -o go-template='{{ index .data "kubeconfig" | base64decode }}' > $TMP_KUBECONFIG
+    KUBECONFIG=$TMP_KUBECONFIG $SHELL
 }
 
 # [khelp] show this help message


### PR DESCRIPTION
Hello, 

The general idea is to reduce a number of dependencies.
First of all `view-secret` plugin, that could be replaced by native `kubectl` functionality.

Then reduce and in the end remove dependency on `jq` (currently used only in `ksearch`)