### PR TITLE
fix: rollback special msys hack

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -5,7 +5,7 @@ then
 fi
 
 # helper functions
-if [ -z "$MSYSTEM" ]; then
+if [ -z "$FUBECTL_MSYS_HACK" ]; then
     alias _kctl_tty="kubectl"
     alias _inline_fzf="fzf --multi --ansi -i -1 --height=50% --reverse -0 --header-lines=1 --inline-info --border"
     alias _inline_fzf_nh="fzf --multi --ansi -i -1 --height=50% --reverse -0 --inline-info --border"


### PR DESCRIPTION
Hello 

I am sorry for bothering with Msys2 stuff last days. 
But I've discovered the better way of setting up msys2 terminal on windows that doesn't require previous hack.

Although, I kept code for possible future usage, that can be enabled by exporting `FUBECTL_MSYS_HACK` env var.