### PR TITLE
Fix --export deprecation

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -257,13 +257,17 @@ function kfor() {
 function ksearch() {
     local search_query="$1"
     [ -z "$search_query" ] && printf "ksearch: missing argument.\nUsage: ksearch SEARCH_QUERY\n" && return 255
-    for ns in $(kubectl get --export -o=json ns | jq -r '.items[] | .metadata.name'); do
-        kubectl --namespace="${ns}" get --export -o=json \
-            deployment,ingress,daemonset,secrets,configmap,service,serviceaccount,statefulsets,pod,endpoints,customresourcedefinition,events,networkpolicies,persistentvolumeclaims,persistentvolumes,replicasets,replicationcontrollers,statefulsets,storageclasses | \
-        jq '.items[]' -c | \
-        grep "$search_query" | \
-        jq -r  '. | [.kind, .metadata.name] | @tsv' | \
-        awk -v prefix="$ns" '{print "kubectl get -n " prefix " " $0}'
+    search_query="$1"
+    for ns in $(kubectl get ns -o=json | jq -r '.items[].metadata.name'); do
+        kubeItems=$(kubectl  --namespace="${ns}" get svc,pods -o=json | jq -r 'del(.metadata.resourceVersion,.metadata.uid,.metadata.selfLink,.metadata.creationTimestamp,.metadata.annotations,.metadata.generation,.metadata.ownerReferences,.status)')
+        items=$(echo "$kubeItems" | jq '.items ' | jq -c .)
+        item_count=$(echo "$kubeItems" | jq '.items | length')
+        for ((i = 0; i < item_count; i++)); do 
+            item=$(echo "$kubeItems" | jq -r ".items[$i]" | jq -c .)
+            if echo "$kubeItems" | jq -r ".items[$i]" | grep "$search_query" > /dev/null 2>&1; then
+                echo $item| jq -r  '. | [.kind, .metadata.name] | @tsv' | awk -v prefix="$ns" '{print "kubectl get -n " prefix " "$0}'
+            fi
+        done
     done
 }
 

--- a/fubectl.source
+++ b/fubectl.source
@@ -259,8 +259,7 @@ function ksearch() {
     [ -z "$search_query" ] && printf "ksearch: missing argument.\nUsage: ksearch SEARCH_QUERY\n" && return 255
     search_query="$1"
     for ns in $(kubectl get ns -o=json | jq -r '.items[].metadata.name'); do
-        kubeItems=$(kubectl  --namespace="${ns}" get svc,pods -o=json | jq -r 'del(.metadata.resourceVersion,.metadata.uid,.metadata.selfLink,.metadata.creationTimestamp,.metadata.annotations,.metadata.generation,.metadata.ownerReferences,.status)')
-        items=$(echo "$kubeItems" | jq '.items ' | jq -c .)
+        kubeItems=$(kubectl  --namespace="${ns}" get deployment,ingress,daemonset,secrets,configmap,service,serviceaccount,statefulsets,pod,endpoints,customresourcedefinition,events,networkpolicies,persistentvolumeclaims,persistentvolumes,replicasets,replicationcontrollers,statefulsets,storageclasses -o=json | jq -r 'del(.metadata.resourceVersion,.metadata.uid,.metadata.selfLink,.metadata.creationTimestamp,.metadata.annotations,.metadata.generation,.metadata.ownerReferences,.status)')
         item_count=$(echo "$kubeItems" | jq '.items | length')
         for ((i = 0; i < item_count; i++)); do 
             item=$(echo "$kubeItems" | jq -r ".items[$i]" | jq -c .)


### PR DESCRIPTION
This change resolves [#91](https://github.com/kubermatic/fubectl/issues/91) by replacing --export with jq. 
Signed-off-by: mehdiouzz <el.mehdi.ouazzane@gmail.com>
