### PR TITLE
Improve kkp-cluster helper

### DIFF
--- a/fubectl.source
+++ b/fubectl.source
@@ -421,6 +421,7 @@ function kkp-cluster() {
     TMP_KUBECONFIG=$(mktemp)
     local cluster="$(kubectl get cluster | _inline_fzf | awk '{print $1}')"
     kubectl get secret admin-kubeconfig -n cluster-$cluster -o go-template='{{ index .data "kubeconfig" | base64decode }}' > $TMP_KUBECONFIG
+    kubectl --kubeconfig $TMP_KUBECONFIG config rename-context default cluster-$cluster
     KUBECONFIG=$TMP_KUBECONFIG $SHELL
 }
 


### PR DESCRIPTION
This will overwrite the default context in the temporary kubeconfig with something meaningful. 
Which, depending on your shell setup, will be included in your prompt and allows to separate cluster prompts from another.